### PR TITLE
ci: use environment files instead of set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Generate Jobs
     runs-on: ubuntu-latest
     outputs:
-      strategy: ${{ steps.generate-jobs.outputs.strategy }}
+      STRATEGY: ${{ steps.generate-jobs.outputs.STRATEGY }}
     steps:
       - uses: actions/checkout@v1
       - id: generate-jobs
@@ -26,13 +26,13 @@ jobs:
           # Force override generated docker image name to "pyenv"
           strategy="$(env GITHUB_REPOSITORY=vicamo/pyenv ~/bashbrew/scripts/github-actions/generate.sh)"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
+          echo "STRATEGY=$strategy" >> $GITHUB_OUTPUT
         env:
           BASHBREW_NAMESPACE: vicamo
 
   test:
     needs: generate-jobs
-    strategy: ${{ fromJson(needs.generate-jobs.outputs.strategy) }}
+    strategy: ${{ fromJson(needs.generate-jobs.outputs.STRATEGY) }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Signed-off-by: You-Sheng Yang (vicamo) <vicamo@gmail.com>